### PR TITLE
Return error if we didn't find a key

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,5 +231,8 @@ int main(int argc, char const *argv[])
             std::cout << "[" << put_time << "] Could not recover password" << std::endl;
     }
 
+    if(keysvec.empty())
+	    return 1;
+
     return 0;
 }


### PR DESCRIPTION
Return 'fail' if we didn't find a key, so we can script testing with alternate plain texts or target files.