### PR TITLE
Add deflate.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+install
+__pycache__/

--- a/tools/deflate.py
+++ b/tools/deflate.py
@@ -4,42 +4,60 @@ import sys
 import zlib
 import argparse
 
-parser = argparse.ArgumentParser(description='Deflate stdin to stdout')
-
-parser.add_argument('--level',
-                    metavar='LEVEL',
-                    type=int,
-                    choices=range(-1, 9 + 1),
-                    help='Compression level (0..9 or -1 for default)',
-                    default=-1)
-
-parser.add_argument('--wsize',
-                    metavar='WSIZE',
-                    type=int,
-                    choices=range(9, 15 + 1),
-                    help='Window size (9..15)',
-                    default=zlib.MAX_WBITS)
-
-parser.add_argument('-z',
-                    action='store_true',
-                    help='Add zlib header to output')
-
-args = parser.parse_args()
-
-def deflate(data, level, wbits):
+def deflate(data, level=-1, wbits=-zlib.MAX_WBITS, strategy=zlib.Z_DEFAULT_STRATEGY):
     """Returns compressed data."""
-    z = zlib.compressobj(level, zlib.DEFLATED, wbits)
-    data = z.compress(data)
-    data += z.flush()
-    return data
+    compressor = zlib.compressobj(level, zlib.DEFLATED, wbits, zlib.DEF_MEM_LEVEL, strategy)
+    return compressor.compress(data) + compressor.flush()
 
 def main():
     """Read uncompressed data from stdin and write deflated data to stdout."""
-    if args.z:
+
+    # Strategies are described in the documentation of the deflateInit2 function in zlib's manual.
+    # See: https://www.zlib.net/manual.html#Advanced
+    zlib_strategies = {
+        'default':      zlib.Z_DEFAULT_STRATEGY,
+        'filtered':     zlib.Z_FILTERED,
+        'huffman_only': zlib.Z_HUFFMAN_ONLY,
+        'rle':          zlib.Z_RLE,
+        'fixed':        zlib.Z_FIXED
+    }
+
+    parser = argparse.ArgumentParser(description='Deflate stdin to stdout')
+
+    parser.add_argument('-l', '--level',
+                        metavar='LEVEL',
+                        type=int,
+                        choices=range(-1, 9 + 1),
+                        help='Compression level (0..9 or -1 for default)',
+                        default=-1)
+
+    parser.add_argument('-w', '--wsize',
+                        metavar='WSIZE',
+                        type=int,
+                        choices=range(9, 15 + 1),
+                        help='Base-two logarithm of the window size (9..15)',
+                        default=zlib.MAX_WBITS)
+
+    parser.add_argument('-s', '--strategy',
+                        metavar='STRATEGY',
+                        choices=zlib_strategies.keys(),
+                        help=f"""Strategy to tune the compression algorithm (choose from '{"', '".join(zlib_strategies)}')""",
+                        default='default')
+
+    parser.add_argument('-z', '--zlib',
+                        action='store_true',
+                        help='Add zlib header and trailer to output. '
+                             'This option is available for the completeness of this script. '
+                             'ZIP files use raw deflate, so do not enable this option '
+                             'if you need compressed plaintext for bkcrack.')
+
+    args = parser.parse_args()
+
+    if args.zlib:
         wbits = args.wsize
     else:
         wbits = -args.wsize
-    sys.stdout.buffer.write(deflate(sys.stdin.buffer.read(), args.level, wbits))
+    sys.stdout.buffer.write(deflate(sys.stdin.buffer.read(), args.level, wbits, zlib_strategies[args.strategy]))
 
 if __name__ == "__main__":
     main()

--- a/tools/deflate.py
+++ b/tools/deflate.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+import sys
+import zlib
+import argparse
+
+parser = argparse.ArgumentParser(description='Deflate stdin to stdout')
+
+parser.add_argument('--level',
+                    metavar='LEVEL',
+                    type=int,
+                    choices=range(-1, 9 + 1),
+                    help='Compression level (0..9 or -1 for default)',
+                    default=-1)
+
+parser.add_argument('--wsize',
+                    metavar='WSIZE',
+                    type=int,
+                    choices=range(9, 15 + 1),
+                    help='Window size (9..15)',
+                    default=zlib.MAX_WBITS)
+
+parser.add_argument('-z',
+                    action='store_true',
+                    help='Add zlib header to output')
+
+args = parser.parse_args()
+
+def deflate(data, level, wbits):
+    """Returns compressed data."""
+    z = zlib.compressobj(level, zlib.DEFLATED, wbits)
+    data = z.compress(data)
+    data += z.flush()
+    return data
+
+def main():
+    """Read uncompressed data from stdin and write deflated data to stdout."""
+    if args.z:
+        wbits = args.wsize
+    else:
+        wbits = -args.wsize
+    sys.stdout.buffer.write(deflate(sys.stdin.buffer.read(), args.level, wbits))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add `tools/deflate.py`, for deflating plaintext to a `-p` file.

I have yet to find a correctly deflated plaintext using this even when I know the original, not deflated, file (presumable because whatever zip binary produced the encrypted archive didn't use zlib), but it's a good tool in the box: If the output size matches, it's a sensible try.