### PR TITLE
Choose a prefix for the password recovery

### DIFF
--- a/include/Arguments.hpp
+++ b/include/Arguments.hpp
@@ -58,6 +58,7 @@ class Arguments
 
         std::size_t maxLength = 0; ///< Maximum password length to try during password recovery
         bytevec charset; ///< Characters to generate password candidates
+        std::string prefix; ///< Expected recovered password prefix
 
         bool help = false; ///< Tell whether help message is needed or not
 

--- a/include/password.hpp
+++ b/include/password.hpp
@@ -14,7 +14,7 @@ class Recovery
         Recovery(const Keys& keys, const bytevec& charset, Progress& progress);
 
         /// Look for a password of length 6 or less
-        bool recoverShortPassword();
+        bool recoverShortPassword(const Keys& initial);
 
         /// Look for a password of given length (at least 7)
         bool recoverLongPassword(const Keys& initial, std::size_t length);
@@ -43,6 +43,6 @@ class Recovery
 };
 
 /// Try to recover the password associated with the given keys
-bool recoverPassword(const Keys& keys, std::size_t max_length, const bytevec& charset, std::string& password, Progress& progress);
+bool recoverPassword(const std::string& prefix, const Keys& keys, std::size_t max_length, const bytevec& charset, std::string& password, Progress& progress);
 
 #endif // BKCRACK_PASSWORD_HPP

--- a/src/Arguments.cpp
+++ b/src/Arguments.cpp
@@ -140,6 +140,9 @@ void Arguments::parseArgument()
             maxLength = readSize("length");
             charset = readCharset();
             break;
+        case 'm':
+            prefix = readString("prefix");
+            break;
         case 'h':
             help = true;
             break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ Optional:
                       ?a alpha-numerical characters (same as ?l?u?d)
                       ?p printable characters (same as ?a?s)
                       ?b all bytes (0x00 - 0xff)
+ -m prefix          The expected starting characters of the password to recover
 
  -h                 Show this help and exit)_";
 
@@ -168,7 +169,7 @@ try
 
         {
             ConsoleProgress progress(std::cout);
-            success = recoverPassword(keysvec.front(), args.maxLength, args.charset, password, progress);
+            success = recoverPassword(args.prefix, keysvec.front(), args.maxLength, args.charset, password, progress);
         }
 
         if(success)


### PR DESCRIPTION
This is a quick hack to be able to set a prefix for the password recovery.
This will be replaced by a proper mask feature.

Example:
`./bkcrack -k f27e56a8 91e5b1ea 709073e0 -r 12 ?p -m "I remember the beginning but then"`
```
[23:53:36] Recovering password
length 0-6...
length 7...
length 8...
length 9...
[23:53:36] Password
as bytes: 49 20 72 65 6d 65 6d 62 65 72 20 74 68 65 20 62 65 67 69 6e 6e 69 6e 67 20 62 75 74 20 74 68 65 6e 20 49 20 66 6f 72 67 6f 74 
as text: I remember the beginning but then I forgot
```

@linux-mining This should work for you.
Related to #55 