### PR TITLE
Better support for UTF-8

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ configure_file("${PROJECT_SOURCE_DIR}/include/version.hpp.in" "${VERSION_HEADER_
 
 # list files
 file(GLOB HEADERS "${PROJECT_SOURCE_DIR}/include/*.hpp")
-file(GLOB SOURCES "${PROJECT_SOURCE_DIR}/src/*.cpp")
+file(GLOB SOURCES "${PROJECT_SOURCE_DIR}/src/*.cpp" "${PROJECT_SOURCE_DIR}/src/*.manifest")
 
 # add the executable target
 add_executable(${PROJECT_NAME} ${VERSION_HEADER_CONFIGURED} ${HEADERS} ${SOURCES})

--- a/src/utf-8.manifest
+++ b/src/utf-8.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <application>
+    <windowsSettings>
+      <!-- As of Windows Version 1903 (May 2019 Update), this sets the process codepage to UTF-8. -->
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
Command line arguments are now UTF-8 encoded on Windows as of Windows Version 1903 (May 2019 Update).
In addition, Info-ZIP extension for UTF-8 entry names is now supported.

Related to #37 and #57.