### PR TITLE
Minimal password length for password recovery

### DIFF
--- a/example/tutorial.md
+++ b/example/tutorial.md
@@ -116,11 +116,12 @@ The internal keys are enough.
 However, we might also be interested in finding the original password.
 To do this, we need to choose a maximum length and a set of characters among which we hope to find those that constitute the password.
 To save time, we have to choose those parameters wisely.
-For a given maximal length, a small charset will be explored much faster than a big one, but making a wrong assumption by choosing a charset that is too small will not allow to recover the password.
+For a given length, a small charset will be explored much faster than a big one, but making a wrong assumption by choosing a charset that is too small will not allow to recover the password.
 
-At first, we can try all candidates up to a given length without making any assumption about the character set. We use the charset `?b` which is the set containing all bytes (from 0 to 255), so we do not miss any candidate up to length 9.
+At first, we can try all candidates up to a given length without making any assumption about the character set.
+We use the charset `?b` which is the set containing all bytes (from 0 to 255), so we do not miss any candidate up to length 9.
 
-    $ ../bkcrack -k c4490e28 b414a23d 91404b31 -r 9 ?b
+    $ ../bkcrack -k c4490e28 b414a23d 91404b31 --bruteforce ?b --length 0..9
 
     [17:52:16] Recovering password
     length 0-6...
@@ -131,36 +132,23 @@ At first, we can try all candidates up to a given length without making any assu
 
 It failed so we know the password has 10 characters or more.
 
-Now, let us assume the password is made of 11 or less printable ASCII characters, using the charset `?p`.
+Now, let us assume the password is made of 10 or 11 printable ASCII characters, using the charset `?p`.
 
-    $ ../bkcrack -k c4490e28 b414a23d 91404b31 -r 11 ?p
+    $ ../bkcrack -k c4490e28 b414a23d 91404b31 --bruteforce ?p --length 10..11
 
     [17:52:34] Recovering password
-    length 0-6...
-    length 7...
-    length 8...
-    length 9...
     length 10...
-    100.0 % (9025 / 9025)
     length 11...
     100.0 % (9025 / 9025)
     [17:52:38] Could not recover password
 
 It failed again so we know the password has non-printable ASCII characters or has 12 or more characters.
 
-Now, let us assume the password is made of 12 or less alpha-numerical characters.
+Now, let us assume the password is made of 12 alpha-numerical characters.
 
-    $ ../bkcrack -k c4490e28 b414a23d 91404b31 -r 12 ?a
+    $ ../bkcrack -k c4490e28 b414a23d 91404b31 --bruteforce ?a --length 12
 
     [17:54:37] Recovering password
-    length 0-6...
-    length 7...
-    length 8...
-    length 9...
-    length 10...
-    100.0 % (3844 / 3844)
-    length 11...
-    100.0 % (3844 / 3844)
     length 12...
     51.8 % (1993 / 3844)
     [17:54:49] Password

--- a/include/Arguments.hpp
+++ b/include/Arguments.hpp
@@ -1,6 +1,7 @@
 #ifndef BKCRACK_ARGUMENTS_HPP
 #define BKCRACK_ARGUMENTS_HPP
 
+#include <limits>
 #include <map>
 #include <optional>
 
@@ -89,14 +90,23 @@ class Arguments
         /// \copydoc ChangeKeys
         std::optional<ChangeKeys> changeKeys;
 
-        /// Arguments needed to attempt a password recovery
-        struct PasswordRecovery
+        /// Characters to generate password candidates
+        std::optional<bytevec> bruteforce;
+
+        /// Range of password lengths to try during password recovery
+        struct LengthInterval
         {
-            std::size_t maxLength; ///< Maximum password length to try during password recovery
-            bytevec charset;       ///< Characters to generate password candidates
+            /// Smallest password length to try (inclusive)
+            std::size_t minLength{0};
+
+            /// Greatest password length to try (inclusive)
+            std::size_t maxLength{std::numeric_limits<std::size_t>::max()};
+
+            /// Compute the intersection between this interval and the given \a other interval
+            LengthInterval operator&(const LengthInterval& other) const;
         };
-        /// \copydoc PasswordRecovery
-        std::optional<PasswordRecovery> recoverPassword;
+        /// \copydoc LengthInterval
+        std::optional<LengthInterval> length;
 
         /// Zip archive about which to display information
         std::optional<std::string> infoArchive;
@@ -131,6 +141,8 @@ class Arguments
             keepHeader,
             changePassword,
             changeKeys,
+            bruteforce,
+            length,
             recoverPassword,
             infoArchive,
             help

--- a/include/password.hpp
+++ b/include/password.hpp
@@ -43,6 +43,6 @@ class Recovery
 };
 
 /// Try to recover the password associated with the given keys
-bool recoverPassword(const Keys& keys, std::size_t max_length, const bytevec& charset, std::string& password, Progress& progress);
+bool recoverPassword(const Keys& keys, const bytevec& charset, std::size_t minLength, std::size_t maxLength, std::string& password, Progress& progress);
 
 #endif // BKCRACK_PASSWORD_HPP

--- a/readme.md
+++ b/readme.md
@@ -136,9 +136,14 @@ It assumes that every entry was originally encrypted with the same password.
 
 ### Recover password
 
-Given the internal keys, bkcrack can try to find the original password up to a given length:
+Given the internal keys, bkcrack can try to find the original password.
+You can look for a password up to a given length using a given character set:
 
     bkcrack -k 1ded830c 24454157 7213b8c5 -r 10 ?p
+
+You can be more specific by specifying a minimal password length:
+
+    bkcrack -k 18f285c6 881f2169 b35d661d -r 11..13 ?p
 
 Learn
 -----


### PR DESCRIPTION
Adding `--bruteforce <charset>` and `--length <length>` options.
Keeping `-r <length> <charset>` as a shortcut.

Length can be an exact value `--length 14` or a range of values `--length 12..16`

Closes #72