### PR TITLE
Do not use OpenMP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Install dependencies
-      if: runner.os == 'macOS'
-      # OpenMP is already installed but for some reason it is not found by CMake unless we explicitly create symlinks.
-      run: brew link --force libomp
-
     - name: Configure CMake
       run: cmake -S . -B build ${{matrix.platform.cmake-config}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-# option to select parallel or serial attack
-option(BKCRACK_PARALLEL_MODE "Enable multithreaded attack with OpenMP." ON)
-
 # option for building the documentation
 option(BKCRACK_BUILD_DOC "Enable documentation generation with doxygen." OFF)
 

--- a/include/Arguments.hpp
+++ b/include/Arguments.hpp
@@ -105,6 +105,9 @@ class Arguments
         /// \copydoc LengthInterval
         std::optional<LengthInterval> length;
 
+        /// Number of threads to use for parallelized operations
+        int jobs;
+
         /// Tell whether to try all candidates (keys or passwords) exhaustively or stop after the first success
         bool exhaustive = false;
 
@@ -143,6 +146,7 @@ class Arguments
             bruteforce,
             length,
             recoverPassword,
+            jobs,
             exhaustive,
             infoArchive,
             help

--- a/include/Attack.hpp
+++ b/include/Attack.hpp
@@ -1,6 +1,8 @@
 #ifndef BKCRACK_ATTACK_HPP
 #define BKCRACK_ATTACK_HPP
 
+#include <mutex>
+
 #include "types.hpp"
 #include "Data.hpp"
 #include "Keys.hpp"
@@ -16,10 +18,11 @@ class Attack
         /// \param data Data used to carry out the attack
         /// \param index Index of Z[2,32) values passed to carry out the attack
         /// \param solutions Shared output vector for valid keys
+        /// \param solutionsMutex Mutex to protect \a solutions from concurrent access
         /// \param exhaustive True to try and find all valid keys,
         ///                   false to stop searching after the first one is found
         /// \param progress Object to report progress
-        Attack(const Data& data, std::size_t index, std::vector<Keys>& solutions, bool exhaustive, Progress& progress);
+        Attack(const Data& data, std::size_t index, std::vector<Keys>& solutions, std::mutex& solutionsMutex, bool exhaustive, Progress& progress);
 
         /// Carry out the attack for the given Z[2,32) value
         void carryout(uint32 z7_2_32);
@@ -48,6 +51,7 @@ class Attack
         const std::size_t index; // starting index of the used plaintext and keystream
 
         std::vector<Keys>& solutions; // shared output vector of valid keys
+        std::mutex& solutionsMutex;
         const bool exhaustive;
         Progress& progress;
 
@@ -60,9 +64,10 @@ class Attack
 /// \param data Data used to carry out the attack
 /// \param zi_2_32_vector Zi[2,32) candidates
 /// \param index Index of the Zi[2,32) values relative to keystream
+/// \param jobs Number of threads to use
 /// \param exhaustive True to try and find all valid keys,
 ///                   false to stop searching after the first one is found
 /// \param progress Object to report progress
-std::vector<Keys> attack(const Data& data, const u32vec& zi_2_32_vector, std::size_t index, bool exhaustive, Progress& progress);
+std::vector<Keys> attack(const Data& data, const u32vec& zi_2_32_vector, std::size_t index, int jobs, bool exhaustive, Progress& progress);
 
 #endif // BKCRACK_ATTACK_HPP

--- a/include/password.hpp
+++ b/include/password.hpp
@@ -2,6 +2,7 @@
 #define BKCRACK_PASSWORD_HPP
 
 #include <bitset>
+#include <mutex>
 
 #include "Keys.hpp"
 #include "Progress.hpp"
@@ -13,7 +14,7 @@ class Recovery
 {
     public:
         /// Constructor
-        Recovery(const Keys& keys, const bytevec& charset, std::vector<std::string>& solutions, bool exhaustive, Progress& progress);
+        Recovery(const Keys& keys, const bytevec& charset, std::vector<std::string>& solutions, std::mutex& solutionsMutex, bool exhaustive, Progress& progress);
 
         /// \brief Look for a password of length 6 or less
         ///
@@ -64,6 +65,7 @@ class Recovery
         bytearr<6> p; // password last 6 bytes
 
         std::vector<std::string>& solutions; // shared output vector of valid passwords
+        std::mutex& solutionsMutex;
         const bool exhaustive;
         Progress& progress;
 };
@@ -73,12 +75,13 @@ class Recovery
 /// \param charset The set of characters with which to constitute password candidates
 /// \param minLength The smallest password length to try
 /// \param maxLength The greatest password length to try
+/// \param jobs Number of threads to use
 /// \param exhaustive True to try and find all valid passwords,
 ///                   false to stop searching after the first one is found
 /// \param progress Object to report progress
 /// \return A vector of passwords associated with the given keys.
 ///         A vector is needed instead of a single string because there can be
 ///         collisions (i.e. several passwords for the same keys).
-std::vector<std::string> recoverPassword(const Keys& keys, const bytevec& charset, std::size_t minLength, std::size_t maxLength, bool exhaustive, Progress& progress);
+std::vector<std::string> recoverPassword(const Keys& keys, const bytevec& charset, std::size_t minLength, std::size_t maxLength, int jobs, bool exhaustive, Progress& progress);
 
 #endif // BKCRACK_PASSWORD_HPP

--- a/readme.md
+++ b/readme.md
@@ -104,10 +104,6 @@ To do so, use the `-x` flag followed by an offset and bytes in hexadecimal.
 
     bkcrack -c cipherfile -p plainfile -x 25 4b4f -x 30 21
 
-#### Number of threads
-
-If bkcrack was built with parallel mode enabled, the number of threads used can be set through the environment variable `OMP_NUM_THREADS`.
-
 ### Decipher
 
 If the attack is successful, the deciphered data associated to the ciphertext used for the attack can be saved:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,11 +18,9 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 # enable C++17
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
-# enable OpenMP if wanted
-if(BKCRACK_PARALLEL_MODE)
-    find_package(OpenMP 2.0 REQUIRED)
-    target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
-endif()
+# let CMake work out the system-specific details to use threads
+find_package(Threads REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 
 # install rules
 install(TARGETS ${PROJECT_NAME} DESTINATION .)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,7 +247,7 @@ try
 
         {
             ConsoleProgress progress(std::cout);
-            passwords = recoverPassword(keysvec.front(), charset, minLength, maxLength, args.exhaustive, progress);
+            passwords = recoverPassword(keysvec.front(), charset, minLength, maxLength, args.jobs, args.exhaustive, progress);
         }
 
         std::cout << "[" << put_time << "] ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,14 +79,12 @@ Options to use the internal password representation:
         Shortcut for --length and --bruteforce options
 
 Other options:
+ -j, --jobs <count>          Number of threads to use for parallelized operations
  -e, --exhaustive            Exhaustively look for all solutions (keys or
                               passwords) instead of stopping after the first
                               solution is found
  -L, --list <archive>        List entries in a zip archive and exit
- -h, --help                  Show this help and exit
-
-Environment variables:
- OMP_NUM_THREADS             Number of threads to use for parallel computations)_";
+ -h, --help                  Show this help and exit)_";
 
 void listEntries(const std::string& archiveFilename);
 void decipher(std::istream& is, std::size_t size, std::size_t discard, std::ostream& os, Keys keys);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,7 @@ try
 
         {
             ConsoleProgress progress(std::cout);
-            keysvec = attack(data, zr.getCandidates(), zr.getIndex(), args.exhaustive, progress);
+            keysvec = attack(data, zr.getCandidates(), zr.getIndex(), args.jobs, args.exhaustive, progress);
         }
 
         // print the keys


### PR DESCRIPTION
Motivation is to get more precise control over the order in which tasks are executed and get rid of a build and runtime dependency.