### PR TITLE
Fix typos in readme and resources md files

### DIFF
--- a/doc/resources.md
+++ b/doc/resources.md
@@ -33,7 +33,7 @@ Resources {#resources}
   [DOI](https://doi.org/10.1007/3-540-45473-X_10)
 
   Reviews Biham and Kocher attack.
-  Suggests a small improvement to require 12 bytes instead of 13 bytes (not throwing aways 6 known bits in Y7).
+  Suggests a small improvement to require 12 bytes instead of 13 bytes (not throwing away 6 known bits in Y7).
   Suggests using CRC-32 check bytes from several files as known plaintext.
 
   Then, it presents other approaches.
@@ -131,7 +131,7 @@ Resources {#resources}
 - [Aloxaf/p7zip](https://github.com/Aloxaf/p7zip)
 
   A patched p7zip by Aloxaf.
-  Supports ZIP file extraction using the interal keys with the following syntax:
+  Supports ZIP file extraction using the internal keys with the following syntax:
 
       7za e cipher.zip '-p[12345678_23456789_34567890]'
 

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ cmake --build build --config Release
 cmake --build build --config Release --target install
 ```
 
-### Thrid-party packages
+### Third-party packages
 
 bkcrack is available in the package repositories listed below.
 Those packages are provided by external maintainers.


### PR DESCRIPTION
## Related Issue / Discussion
There are a few small typos in the primary `readme.md` file and the `doc/resources.md` file.

## Patch Description
This patch replaces: 
- `Thrid` with `Third` in [readme.md](https://github.com/kimci86/bkcrack/blame/6d79d2c24d7702d4a1fa5a3048fc157f6a9a5336/readme.md#L56)
- `aways` with `away` in [resources.md](https://github.com/kimci86/bkcrack/blame/6d79d2c24d7702d4a1fa5a3048fc157f6a9a5336/doc/resources.md#L36)
- `interal` with `internal` in [resources.md](https://github.com/kimci86/bkcrack/blame/6d79d2c24d7702d4a1fa5a3048fc157f6a9a5336/doc/resources.md#L134)

## Testing Instructions
No testing is required. The change is purely semantic.

## Other Information
Thanks for sharing this great tool! 
